### PR TITLE
feat: generate advertisement data dynamically

### DIFF
--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -11,9 +11,9 @@ var isIntelEdison = isLinux && (os.release().indexOf('edison') !== -1);
 var isYocto = isLinux && (os.release().indexOf('yocto') !== -1);
 
 function Gap(hci) {
-  this._hci = hci;
-
+  this.ADVERTISEMENT_CHANGE_INTERVAL = 1000;
   this._advertiseState = null;
+  this._hci = hci;
 
   this._hci.on('error', this.onHciError.bind(this));
 
@@ -135,8 +135,15 @@ Gap.prototype.startAdvertisingIBeacon = function(data) {
   this.startAdvertisingWithEIRData(advertisementData, scanData);
 };
 
-Gap.prototype.startAdvertisingWithEIRData = function(advertisementData, scanData) {
-  advertisementData = advertisementData || new Buffer(0);
+Gap.prototype.startAdvertisingWithEIRData = function(getAdvertisementData, scanData) {
+  var isDynamicAdData = typeof getAdvertisementData === 'function';
+  var advertisementData = null;
+  if (isDynamicAdData) {
+    advertisementData = getAdvertisementData();
+  } else {
+    advertisementData = getAdvertisementData || new Buffer(0);
+  }
+
   scanData = scanData || new Buffer(0);
 
   debug('startAdvertisingWithEIRData: advertisement data = ' + advertisementData.toString('hex') + ', scan data = ' + scanData.toString('hex'));
@@ -164,7 +171,18 @@ Gap.prototype.startAdvertisingWithEIRData = function(advertisementData, scanData
     this._hci.setAdvertiseEnable(true);
     this._hci.setScanResponseData(scanData);
     this._hci.setAdvertisingData(advertisementData);
+
+    if (isDynamicAdData) {
+      var setNewData = () => {
+        advertisementData = getAdvertisementData(advertisementData);
+        this._hci.setAdvertisingData(advertisementData);
+      }
+      setInterval(setNewData, this.ADVERTISEMENT_CHANGE_INTERVAL);
+    } else {
+      this._hci.setAdvertisingData(advertisementData);
+    }
   }
+
 };
 
 Gap.prototype.restartAdvertising = function() {

--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -13,6 +13,7 @@ var isYocto = isLinux && (os.release().indexOf('yocto') !== -1);
 function Gap(hci) {
   this.ADVERTISEMENT_CHANGE_INTERVAL = 1000;
   this._advertiseState = null;
+  this._advertisementDataIntervalId = null;
   this._hci = hci;
 
   this._hci.on('error', this.onHciError.bind(this));
@@ -173,11 +174,12 @@ Gap.prototype.startAdvertisingWithEIRData = function(getAdvertisementData, scanD
     this._hci.setAdvertisingData(advertisementData);
 
     if (isDynamicAdData) {
-      var setNewData = () => {
+      var ctx = this;
+      var setNewData = function () {
         advertisementData = getAdvertisementData(advertisementData);
-        this._hci.setAdvertisingData(advertisementData);
-      }
-      setInterval(setNewData, this.ADVERTISEMENT_CHANGE_INTERVAL);
+        ctx._hci.setAdvertisingData(advertisementData);
+      };
+      this._advertisementDataIntervalId = setInterval(setNewData, this.ADVERTISEMENT_CHANGE_INTERVAL);
     } else {
       this._hci.setAdvertisingData(advertisementData);
     }
@@ -193,6 +195,10 @@ Gap.prototype.restartAdvertising = function() {
 
 Gap.prototype.stopAdvertising = function() {
   this._advertiseState = 'stopping';
+
+  if (this._advertisementDataIntervalId) {
+    clearInterval(this._advertisementDataIntervalId);
+  }
 
   this._hci.setAdvertiseEnable(false);
 };


### PR DESCRIPTION
Modified the `Bleno.startAdvertisingWithEIRData` signature to accept a function that returns the payload, instead of just the payload itself. Backwards compatibility is preserved.

The payload function is called at intervals of 1000ms, and is called with the previous payload as an argument.
