### PR TITLE
feat: expose method to set EIR data

### DIFF
--- a/lib/bleno.js
+++ b/lib/bleno.js
@@ -189,6 +189,10 @@ Bleno.prototype.startAdvertisingWithEIRData = function(advertisementData, scanDa
   }
 };
 
+Bleno.prototype.setAdvertisementEIRData = function (data) {
+  this._bindings.setAdvertisementEIRData(data);
+};
+
 Bleno.prototype.stopAdvertising = function(callback) {
   if (callback) {
     this.once('advertisingStop', callback);

--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -43,6 +43,10 @@ BlenoBindings.prototype.startAdvertisingWithEIRData = function(advertisementData
   this._gap.startAdvertisingWithEIRData(advertisementData, scanData);
 };
 
+BlenoBindings.prototype.setAdvertisementEIRData = function(advertisementData) {
+  this._gap.setAdvertisementEIRData(advertisementData);
+};
+
 BlenoBindings.prototype.stopAdvertising = function() {
   this._advertising = false;
 

--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -167,6 +167,16 @@ Gap.prototype.startAdvertisingWithEIRData = function(advertisementData, scanData
   }
 };
 
+Gap.prototype.setAdvertisementEIRData = function (advertisementData) {
+  advertisementData = advertisementData || new Buffer(0);
+
+  if (advertisementData.length > 31) {
+    console.error('Advertisement data is over maximum limit of 31 bytes. Data has not been set.');
+  } else {
+    this._hci.setAdvertisingData(advertisementData);
+  }
+};
+
 Gap.prototype.restartAdvertising = function() {
   this._advertiseState = 'restarting';
 


### PR DESCRIPTION
Allows the client to change the EIR data of an advertising device by calling `Bleno.setAdvertisementEIRData()` with a new Buffer object.